### PR TITLE
Refactor of Make, CMake, and Git Sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,31 +297,31 @@ Now if you run `cmake3 .` and `make` you will see two executables generated `are
 
 ### Git Config
 
-Git is a local program for performing version control, which is also capable of working with a remote git server for saving code off site. GitHub is a web-based Git repository, which the local Git program is capable of interfacing with. Git and GitHub are therefore two seperate systems and Git needs to be configured correctly in order for your code changes to be tracked correctly. You should run the following commands on any new system you are committing from before you start working (these can be run from any directory):
+Git is a local program for performing version control which is usually paired with a remote git server for saving code off site. GitHub is a web-based Git repository which your local Git program is capable of interfacing with. Git and GitHub are therefore two seperate systems and Git needs to be configured correctly in order for your code changes to be tracked and attributed correctly on GitHub. You should run the following commands on any new system you are committing from before you start working (these can be run from any directory and only have to be run once per system):
 
 ```sh
-git config --global user.name "<first-name last-name>"
+git config --global user.name "<github-username>"
 git config --global user.email <github-registered-email>
 ```
 
-GitHub will use the user email that you configure with your Git client to track which users are creating what commits. This means that you'll need to use the email address you've registered with GitHub in the above configurations (otherwise you may see commits from an anonymous user)
+GitHub will use the email that you configure with your Git client to track which users are making which changes. This means that you'll need to use the email address you've registered with GitHub in the above configurations (otherwise you may see commits from an anonymous user). In this course we look at commits and who made them to make sure partners in the projects and labs are contributing equally, so having misattributed commits may lead to point deductions. If you have a few which are misattribued this is not an issue but you should configure your client quickly after you notice the problem to correct the issue.
 
 ### Git Init & Clone
 
-The traditional way to start a new project in Git is to create a new directory and change into it. Make sure you are back at your home directory (`cd ~`). Go ahead and run the following commands on the terminal in `hammer`:
+New Git repositories can be created either locally using the git client or through GitHub directly. Make sure you are back at your home directory (`cd ~`) and run the following commands on the terminal in `hammer`:
 
 ```sh
 mkdir lab-01
 cd lab-01
 ```
 
-Then to initialize that directory as a Git project, use the following Git initialization command:
+Then to initialize that directory as a Git project, use the following Git command:
 
 ```sh
 git init
 ```
 
-This will create a hidden `.git` repository which holds all the information that Git uses to keep track of your files and changes. The folder is hidden because it begins with a period (recall earlier in the lab).
+This will create a hidden `.git` repository (which you can see with `ls -a`) that holds all the information that Git uses to keep track of your files and changes. The folder is hidden because it begins with a period (recall earlier in the lab) and is typically not modified by users directly.
 
 However, you use a different method if you want to receive a copy of an already existing repository, which you will do for all of the labs and assignments in this course. Rather than initializing a new repository, you will make a “clone” of a repository that already exists. Start by moving out of the git project you just created and removing that directory:
 
@@ -346,7 +346,7 @@ Replacing the above `<github-url>` with the url that you copied from the “Clon
 
 ### Git Status, Add & Commit
 
-Remember our program and its source/header files from earlier? Go ahead and move all of those files into the `lab-01-linux-intro-...` folder.
+Remember our program and its source/header files from earlier? Go ahead and move all of those files into the new `lab-01-linux-intro-...` folder.
 
 Git doesn’t automatically keep track of new files for us. Instead, we have to tell Git to start tracking these new files. Run the following command:
 
@@ -354,40 +354,29 @@ Git doesn’t automatically keep track of new files for us. Instead, we have to 
 git status
 ```
 
-In the output, there is a section labeled "untracked files." Notice the files in that section. This means that Git knows these files exist, but isn’t currently keeping track of changes to them. We want to keep track of all the `.cpp` `.hpp` files and `CMakeLists.txt`, but not the `area_calculator` file since that should be recompiled to run correctly on different machines.
+The `status` command lists the current status of your Git repository, mostly showing whcih files have changes. In the output, there is a section labeled "untracked files." Notice the files in that section. This means that Git knows these files exist, but isn’t currently keeping track of changes to them. We want to keep track of all the `.cpp` `.hpp` files and `CMakeLists.txt`, but not the `area_calculator` file since that should be recompiled to run correctly on different machines. It is important to note that Git does not automatically save changes to your files either locally or on GitHub. When you have made a set of changes that you want to save you will have to use the comands we are going to introduce below so you will use these commands very often.
 
-We don’t want Git to continue to tell us that `area_calculator` is untracked, but luckily Git has a solution for this problem. You can create a file called `.gitignore` that will contain a list of all of the files that you want Git to ignore when it tells you what is/isn’t tracked and modified. Create a `.gitignore` file and add `area_calculator` to that file. You can use the following command to do that:
-
-```sh
-echo “area_calculator” > .gitignore
-```
-
-The echo command will output the string `“area_calculator”` to terminal, which will then be redirected (`>`) to the `.gitignore` file (which will be created if it doesn’t already exist). Now check the status of your repo:
-
-```sh
-git status
-```
-
-Notice that a.out is no longer listed, only the `.cpp` `.hpp`, `CMakeLists.txt` and the new `.gitignore` files are listed as untracked. Now, we can add all of these files to our project with the following commands:
+We don’t want Git to continue to tell us that `area_calculator` is untracked, but luckily Git has a solution for this problem. You can create a file called `.gitignore` that will contain a list of all of the files that you want Git to ignore when it tells you what is/isn’t tracked and modified. Create a file named `.gitignore` and add `area_calculator` to it. Now run `git status` again and take a look at the output. Notice that `area_calculator` is no longer listed, only the `.cpp` `.hpp`, `CMakeLists.txt` and the new `.gitignore` files are listed as untracked. Now, we can add all of these files to our project with the following commands:
 
 ```sh
 git add header/rectangle.hpp
 git add src/rectangle.cpp
 git add src/main.cpp
+git add src/new_main.cpp
 git add .gitignore
 ```
 
-> Note: Do not add executable or object files to your git repo, only add source files. Tracking executables uses LOTS of disk space and they are unlikely to work on other peoples machines. **If we see these files in your Git repos, your grade on the assignment will be docked 20%**. You should use a `.gitignore` file so that they don’t appear in your Git status or accidentally get added to your repository.
+> Note: Do not add executables, object files, or temporary files which are re-generated during compilation to your git repo, only add source files and other necessary files for your submission (these are listed in the assignment specifications). Tracking executables uses LOTS of disk space and they are unlikely to work on other peoples machines. **If we see these files in your Git repos, your grade on the assignment will be docked 20%**. You should use a `.gitignore` file so that they don’t appear in your Git status or accidentally get added to your repository.
 
 Now, when we run Git status, there is a section labeled "Changes to be committed" with the files that were just added underneath it. This means that Git now thinks these files are part of the project, and will begin to track changes to it.
 
 Whenever we finish a task in our repo, we "commit" our changes. This tells Git to save the current state of the repo, made up of all the files we’ve added, so that we can come back to it later if we need to. Commit your changes using the command:
 
 ```sh
-git commit -m "my first commit”
+git commit -m "Add initial files”
 ```
 
-Every commit needs a "commit message" that describes what changes we made in the repo. Writing clear, succinct, informative commit messages is one of the keys to using Git effectively. In this case we passed the -m flag to Git so the commit message was specified in the command line. If we did not pass a flag, then Git would have opened the Vim editor for us to type a longer commit message.
+Every commit needs a "commit message" that describes what changes we made in the repo. Writing clear, succinct, informative commit messages is one of the keys to using Git effectively. In this case we passed the `-m` flag to Git so we could write the commit message in the command line. If we did not pass a flag, then Git would have opened the Vim editor for us to type a longer commit message which is useful when you are commiting more major changes which require more explination.
 
 That was not a very informative commit message, so lets edit it to be something more informative. Anytime you need to modify the last commit that you made, you need to amend it, which is done through the following command:
 
@@ -465,11 +454,14 @@ int main()
 {
 	Rectangle rect1, rect2;
 	rect1.set_width(3);
-    	rect1.set_height(4);
+    rect1.set_height(4);
+
 	rect2.set_width(4);
-    	rect2.set_height(2);
+    rect2.set_height(2);
+
 	cout << "Rectangle 1 area: " << rect1.area() << endl;
 	cout << "Rectangle 2 area: " << rect2.area() << endl;
+
 	return 0;
 }
 ```
@@ -499,7 +491,7 @@ $ git commit -m "Add one more rectangle and compute its area”
 
 ### Git Push & Pull
 
-While git is a VCS, GitHub is a remote repository, which is an important distinction for two reasons. The first is that up until now all the work you’ve done has only been saved locally, so if there is a problem with your computer you would have no backup and therefore no way to recover the files. The second is that because all the changes are local, there is no way for people collaborating with you to see your changes or merge them into their own branches (merging and branching will be discussed in a future lab). Go to your GitHub repository for this lab, and you should see that none of the work you've done is listed.
+While git is a version control system (VCS), GitHub is a remote repository which is an important distinction for two reasons. The first is that up until now all the work you’ve done has only been saved locally, so if there is a problem with your computer you would have no backup and therefore no way to recover the files. The second is that because all the changes are local, there is no way for people collaborating with you to see or receive your changes. Go to your GitHub repository for this lab, and you should see that none of the work you've done is listed.
 
 Since we cloned the remote repository from GitHub directly, our local repository is already associated with a remote repository (usually referred to as “remote” or “upstream”). In order to send the changes we’ve made locally to GitHub, we just need to “push” them up to the server (do this now).
 
@@ -507,20 +499,8 @@ Since we cloned the remote repository from GitHub directly, our local repository
 $ git push
 ```
 
-This will push all the commits you've made since your most recent push. If there haven’t been any other changes to the remote GitHub version, then this will simply send the commits to the repo. However, if there have been changes to the branch (perhaps because someone else has also been working on that same branch or changes have been merged into master), then you will first need to “pull” the remote changes, merge them with your work, and then push the merged version to GitHub:
-
-```sh
-$ git pull
-```
-
-It is also possible to receive the remote changes (also known as upstream changes) without having Git automatically attempt to merge them into your branch. For this you would use the following command:
-
-```sh
-$ git fetch
-```
-
-After this, you can do a Git merge to integrate the remote changes. `git pull` essentially runs a `git fetch` and a `git merge` together in one step. You will be using `git push` and `git pull` extensively in your projects for this course, and merge conflicts will likely occur fairly regularly.
+This will push all the commits you've made since your last push assuming there haven't been any changes to the remote GitHub repo that your local Git doesn't know about. If there have been you will need to "pull" and "merge" those changes into your local repository, but we will cover those steps in a future lab when we cover Git and GitHub in more depth.
 
 ## Submission
 
-None of the labs or assignments for this course require direct submissions. Everything will be graded based on your GitHub repositories. Labs will be graded based on the last commit to the repository, while projects will be graded based on specific tags (tags will be explained in a future lab).
+None of the labs or assignments for this course require direct submissions but will be graded based on your GitHub repositories. Projects will be graded based on specific tags (we will explain tags in a future lab) and labs will be graded based on your last GitHub commit and a demonstration of your code to your TA. Since you have just pushed your code to GitHub you now need to demonstrate that you have completed the lab to the TA.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ int main()
 {
 	Rectangle rect;
 	rect.set_width(3);
-    	rect.set_height(4);
+    rect.set_height(4);
 	cout << "Rectangle area: " << rect.area() << endl;
 	return 0;
 }
@@ -217,7 +217,7 @@ Notice that we didn't include the header file `rectangle.hpp` as an argument. Th
 
 ### Make
 
-Now we briefly introduce Make, GNU's build automation tool. It automatically builds executables from source code by reading a file called the `Makefile` which tells Make how to build the target program. The `Makefile` is made up of rules, that look like the following:
+Now we briefly introduce Make which is a GNU project build automation tool. Make is essentially a scripting language for building executables from source code. It works by reading a `Makefile` (that is the required file name) which is a text file that tells Make how to build the target program. The `Makefile` is made up of rules, that look like the following:
 
 ```make
 target:	dependencies ...
@@ -232,11 +232,11 @@ area_calculator: src/main.cpp src/rectangle.cpp
 	g++ -o area_calculator src/main.cpp src/rectangle.cpp
 ```
 
-Save and quit. Now, go ahead and run `make`. You should see the rule's command displayed as output. By this point, you hopefully see the potential in using `make`; you don't need to keep entering `g++ -o area_calculator main.cpp rectangle.cpp` over and over again when making edits to the source files.
+Now go ahead and run `make` in your terminal and you should see the rule's command displayed as output. Using `make` allows you to save lots of time typing out compilations commands so you don't need to keep entering `g++ -o area_calculator main.cpp rectangle.cpp` over and over again when making edits to the source files. It also allows you to create multiple executables from a single command. However, we won't be using make directly in this course but instead a more powerful system.
 
 ### CMake
 
-[CMake](https://cmake.org/) is a build system built on top of GNU's `make` and supports some more advanced features. The CMake system looks for a CMakeLists.txt file in order to know what to build, so start by creating the following CMakeLists.txt file:
+[CMake](https://cmake.org/) is a build system built on top of GNU's `make` and supports some more advanced features. The CMake system looks for a `CMakeLists.txt` file (again this is the required file name) in order to know what to build. Start by creating the following `CMakeLists.txt` file:
 
 ```cmake
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
@@ -253,7 +253,7 @@ The first function, `CMAKE_MINIMUM_REQUIRED`, sets the minimum version of CMake 
 $ cmake3 .
 ```
 
-This command envokes the CMake build system in the local directory (where our CMakeLists.txt file is located). **Make sure you use the `cmake3` command and not just `cmake`**. Hammer has two version of CMake installed, and if you do not use the `cmake3` command you will get an error (note that you will likely just use the `cmake` command when you develop on your local environment, since you will only have one version of CMake installed). You should now have an updated `Makefile` that matches the executable that we asked for in our CMakeLists.txt. Go ahead and envoke the `Makefile` (type `make`). You should see a nicely designed build percentage which will generate a new `area_calculator` executable.
+This command envokes the CMake build system in the local directory (where our CMakeLists.txt file is located). **Make sure you use the `cmake3` command and not just `cmake`**. Hammer has two version of CMake installed because of the tool sourcing we did at the beginning of the lab, and if you do not use the `cmake3` command you will get an error. If you are developing on your own machine will likely just use the `cmake` command, since you will only have one version of CMake installed. CMake should now have generated a new `Makefile` so execute the `Makefile` with the `make` command. You should see a nicely designed build percentage which will generate a new `area_calculator` executable.
 
 ```sh
 $ make
@@ -263,6 +263,35 @@ Scanning dependencies of target area_calculator
 [100%] Linking CXX executable area_calculator
 [100%] Built target area_calculator
 ```
+
+As you may have guessed CMake and Make both allow you to generate multiple executables. In this class we will use this functionality to build executables for the regular program and for testing. Lets try creating another executable by creating another main which runs a slightly different program. Create a file with the following code named `new_main.cpp` in the `src` directory:
+
+```c++
+#include <iostream>
+#include "../header/rectangle.hpp"
+
+using namespace std;
+
+int main()
+{
+	Rectangle rect;
+	rect.set_width(15);
+    rect.set_height(30);
+	cout << "Rectangle area: " << rect.area() << endl;
+	return 0;
+}
+```
+
+Now add the following snippet of code to the `CMakeLists.txt` file you created previously:
+
+```cmake
+ADD_EXECUTABLE(bigger_area_calculator
+    src/new_main.cpp
+    src/rectangle.cpp
+)
+```
+
+Now if you run `cmake3 .` and `make` you will see two executables generated `area_calculator` and `bigger_area_calculator`. If you want to only build one of the executables (for example if you updated only one of the mains) then you can invoke `make` with the name of the executable you want it to build, `make area_calculator` for example, and it will only build that one executable.
 
 ## Intro to Git and Github
 
@@ -457,14 +486,14 @@ Every time you modify a file, you must explicitly tell Git to add the file again
 
 Run `git status` to see the files that are currently being tracked. We can add the changes to the `main.cpp` file, and verify it is added, with:
 
-```
+```sh
 $ git add main.cpp
 $ git status
 ```
 
 We can then commit the changes using:
 
-```
+```sh
 $ git commit -m "Add one more rectangle and compute its area”
 ```
 
@@ -474,19 +503,19 @@ While git is a VCS, GitHub is a remote repository, which is an important distinc
 
 Since we cloned the remote repository from GitHub directly, our local repository is already associated with a remote repository (usually referred to as “remote” or “upstream”). In order to send the changes we’ve made locally to GitHub, we just need to “push” them up to the server (do this now).
 
-```
+```sh
 $ git push
 ```
 
 This will push all the commits you've made since your most recent push. If there haven’t been any other changes to the remote GitHub version, then this will simply send the commits to the repo. However, if there have been changes to the branch (perhaps because someone else has also been working on that same branch or changes have been merged into master), then you will first need to “pull” the remote changes, merge them with your work, and then push the merged version to GitHub:
 
-```
+```sh
 $ git pull
 ```
 
 It is also possible to receive the remote changes (also known as upstream changes) without having Git automatically attempt to merge them into your branch. For this you would use the following command:
 
-```
+```sh
 $ git fetch
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Another example of a hidden file used by a system is the `.bashrc` file, which y
 
 # Source global definitions
 if [ -f /etc/bashrc ]; then
-	. /etc/bashrc
+    . /etc/bashrc
 fi
 
 # Uncomment the following line if you don't like systemctl's auto-paging feature:
@@ -121,8 +121,8 @@ using namespace std;
 
 int main()
 {
-	cout << "hello world!" << endl;
-	return 0;
+    cout << "hello world!" << endl;
+    return 0;
 }
 ```
 
@@ -155,13 +155,13 @@ Before we write our files, lets create some directories to seperate our files an
 #define RECTANGLE_HPP
 
 class Rectangle {
-	private:
-		int width;
-		int height;
-	public:
-        	void set_width(int w);
-        	void set_height(int h);
-		int area();
+    private:
+        int width;
+        int height;
+    public:
+        void set_width(int w);
+        void set_height(int h);
+        int area();
 };
 
 #endif /* RECTANGLE_HPP */
@@ -175,15 +175,15 @@ Also create a source file called `rectangle.cpp` in the `src` directory, and add
 #include "../header/rectangle.hpp"
 
 void Rectangle::set_width(int w) {
-	this->width = w;
+    this->width = w;
 }
 
 void Rectangle::set_height(int h) {
-    	this->height = h;
+    this->height = h;
 }
 
 int Rectangle::area() {
-	return this->width * this->height;
+    return this->width * this->height;
 }
 ```
 
@@ -197,11 +197,11 @@ using namespace std;
 
 int main()
 {
-	Rectangle rect;
-	rect.set_width(3);
+    Rectangle rect;
+    rect.set_width(3);
     rect.set_height(4);
-	cout << "Rectangle area: " << rect.area() << endl;
-	return 0;
+    cout << "Rectangle area: " << rect.area() << endl;
+    return 0;
 }
 ```
 
@@ -220,16 +220,16 @@ Notice that we didn't include the header file `rectangle.hpp` as an argument. Th
 Now we briefly introduce Make which is a GNU project build automation tool. Make is essentially a scripting language for building executables from source code. It works by reading a `Makefile` (that is the required file name) which is a text file that tells Make how to build the target program. The `Makefile` is made up of rules, that look like the following:
 
 ```make
-target:	dependencies ...
-	commands
-	...
+target: dependencies ...
+    commands
+    ...
 ```
 
 Let's go ahead and create a `Makefile` for our program above. Add the following rule into the `Makefile`:
 
 ```make
 area_calculator: src/main.cpp src/rectangle.cpp
-	g++ -o area_calculator src/main.cpp src/rectangle.cpp
+    g++ -o area_calculator src/main.cpp src/rectangle.cpp
 ```
 
 Now go ahead and run `make` in your terminal and you should see the rule's command displayed as output. Using `make` allows you to save lots of time typing out compilations commands so you don't need to keep entering `g++ -o area_calculator main.cpp rectangle.cpp` over and over again when making edits to the source files. It also allows you to create multiple executables from a single command. However, we won't be using make directly in this course but instead a more powerful system.
@@ -274,11 +274,11 @@ using namespace std;
 
 int main()
 {
-	Rectangle rect;
-	rect.set_width(15);
+    Rectangle rect;
+    rect.set_width(15);
     rect.set_height(30);
-	cout << "Rectangle area: " << rect.area() << endl;
-	return 0;
+    cout << "Rectangle area: " << rect.area() << endl;
+    return 0;
 }
 ```
 
@@ -452,17 +452,17 @@ using namespace std;
 
 int main()
 {
-	Rectangle rect1, rect2;
-	rect1.set_width(3);
+    Rectangle rect1, rect2;
+    rect1.set_width(3);
     rect1.set_height(4);
 
-	rect2.set_width(4);
+    rect2.set_width(4);
     rect2.set_height(2);
 
-	cout << "Rectangle 1 area: " << rect1.area() << endl;
-	cout << "Rectangle 2 area: " << rect2.area() << endl;
+    cout << "Rectangle 1 area: " << rect1.area() << endl;
+    cout << "Rectangle 2 area: " << rect2.area() << endl;
 
-	return 0;
+    return 0;
 }
 ```
 


### PR DESCRIPTION
* Add second executable target in CMake section
* Remove section on input redirection in terminal
* Remove section on pull and merge in favor of covering it in Git & GitHub lab
* Generally refactor text